### PR TITLE
DfciPkg/UiSupport: Fix bad size in memory alloc

### DIFF
--- a/DfciPkg/IdentityAndAuthManager/UiSupport.c
+++ b/DfciPkg/IdentityAndAuthManager/UiSupport.c
@@ -365,7 +365,7 @@ UiEnrollRequest (
 
   CertText = QueryCertificateDetails (TrustedCert, TrustedCertSize);
   if (CertText == NULL) {
-    CertText    = AllocatePool (L'\0');
+    CertText    = AllocatePool (sizeof (L'\0'));
     CertText[0] = L'\0';
   }
 


### PR DESCRIPTION
## Description

`AllocatePool ()` takes a `UINTN` argument that specifies the size
of buffer to allocate. If the size is `0`, a buffer of size `0` is
returned.

The code modified here calls `AllocatePool ()` as follows:
  `CertText    = AllocatePool (L'\0');`

The single wide-character literal `\0` has an integer value of zero.

This change updates the call to be `sizeof (L'\0')` which will
pass the bytes required to hold the character.

This will allow the buffer to hold the character in the following
assignment to the buffer:

  `CertText[0] = L'\0';`

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Compile DfciPkg with change

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
