### PR TITLE
.pytool/CISettings.py: Use all CodeQL filter files

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
+import glob
 import os
 import logging
 import sys
@@ -177,6 +178,14 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
                     shell_environment.GetBuildVars().SetValue(
                         "STUART_CODEQL_AUDIT_ONLY",
                         "TRUE",
+                        "Set in CISettings.py")
+                    codeql_filter_files = [str(n) for n in glob.glob(
+                        os.path.join(self.GetWorkspaceRoot(),
+                            '**/CodeQlFilters.yml'),
+                        recursive=True)]
+                    shell_environment.GetBuildVars().SetValue(
+                        "STUART_CODEQL_FILTER_FILES",
+                        ','.join(codeql_filter_files),
                         "Set in CISettings.py")
             except NameError:
                 pass


### PR DESCRIPTION
## Description

Updates the CodeQL file filter list to include all filters found in
the repo. This will pick up filters from repos like mu_basecore.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified CodeQL filter files being used are expected.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>