### PR TITLE
Update buffer size for string of DFCI setting

### DIFF
--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -332,11 +332,10 @@ SetProviderValueFromAscii (
   return Status;
 }
 
-#define ENABLED_STRING_SIZE                (9)
-#define ASSET_TAG_STRING_MAX_SIZE          (22)
+#define ENABLED_STRING_SIZE                (13)
 #define SECURE_BOOT_ENUM_STRING_SIZE       (20)
 #define SYSTEM_PASSWORD_STATE_STRING_SIZE  (30)
-#define USB_PORT_STATE_STRING_SIZE         (20)
+#define USB_PORT_STATE_STRING_SIZE         (21)
 
 /**
 Helper function to Print out the Value as Ascii text.


### PR DESCRIPTION
Fixes #41 

## Description

1. Increase ENABLED_STRING_SIZE & USB_PORT_STATE_STRING_SIZE so that the buffer allocated can be big enough to accommodate the string of DFCI setting, otherwise the generated DFCI setting string will be truncated.
2. Remove define of ASSET_TAG_STRING_MAX_SIZE which is no longer used.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified with SEMM tool: 
1. Set USB port to UsbPortAuthenticated via ConfigureSEMM.ps1 
2. Reboot 
3. Verify with CurrentSettings.ps1. The USB port is in correct mode.

## Integration Instructions

N/A
