### PR TITLE
Update lock test pass message to avoid confusion

### DIFF
--- a/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTest.c
+++ b/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTest.c
@@ -342,7 +342,7 @@ DfciLockTestEntry (
     goto Exit;
   } else {
     if (gDfciPolicyFailedCount == 0) {
-      AddDfciErrorToNode (gDfciStatusNode, "Dfci variable checks completed successfully");
+      AddDfciPassToNode (gDfciStatusNode, "Dfci variable checks completed successfully");
     } else {
       AddDfciErrorToNode (gDfciStatusNode, "Dfci variable checks found errors");
     }

--- a/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTestXml.c
+++ b/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTestXml.c
@@ -453,6 +453,19 @@ AddDfciErrorToNode (
 {
   EFI_STATUS  Status;
 
-  Status = AddNode (StatusNode, VAR_DFCI_CHECK_ELEMENT_NAME, DfciStatusString, NULL);
+  Status = AddNode (StatusNode, VAR_DFCI_ERROR_ELEMENT_NAME, DfciStatusString, NULL);
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+AddDfciPassToNode (
+  IN XmlNode  *StatusNode,
+  IN CHAR8    *DfciStatusString
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = AddNode (StatusNode, VAR_DFCI_PASS_ELEMENT_NAME, DfciStatusString, NULL);
   return Status;
 }

--- a/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTestXml.h
+++ b/DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciLockTestXml.h
@@ -47,7 +47,8 @@
 #define VAR_READ_STATUS_ELEMENT_NAME   "ReadStatus"
 #define VAR_WRITE_STATUS_ELEMENT_NAME  "WriteStatus"
 #define DFCI_ENTRY_ELEMENT_NAME        "DfciStatus"
-#define VAR_DFCI_CHECK_ELEMENT_NAME    "DfciError"
+#define VAR_DFCI_ERROR_ELEMENT_NAME    "DfciError"
+#define VAR_DFCI_PASS_ELEMENT_NAME     "DfciPass"
 
 /**
 Creates a new XmlNode list following the List
@@ -121,6 +122,13 @@ New_DfciStatusNodeInList (
 EFI_STATUS
 EFIAPI
 AddDfciErrorToNode (
+  IN XmlNode  *Node,
+  IN CHAR8    *DfciMessage
+  );
+
+EFI_STATUS
+EFIAPI
+AddDfciPassToNode (
   IN XmlNode  *Node,
   IN CHAR8    *DfciMessage
   );


### PR DESCRIPTION
# Preface

## Description

Change the Pass message to not be associated with an error message.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
