### PR TITLE
Refactor ProviderValueAsAscii()

### DIFF
--- a/DfciPkg/Include/DfciSystemSettingStrings.h
+++ b/DfciPkg/Include/DfciSystemSettingStrings.h
@@ -56,6 +56,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DFCI_STR_INCONSISTENT        "Inconsistent"
 #define DFCI_STR_UNKNOWN             "Unknown"
 #define DFCI_STR_UNSUPPORTED_VALUE   "UnsupportedValue"
-#define DRCI_STR_CERT_NOT_AVAILABLE  "No Cert information available"
+#define DFCI_STR_CERT_NOT_AVAILABLE  "No Cert information available"
+
 
 #endif // __DFCI_SETTING_STRINGS_H__

--- a/DfciPkg/Include/DfciSystemSettingStrings.h
+++ b/DfciPkg/Include/DfciSystemSettingStrings.h
@@ -58,5 +58,4 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DFCI_STR_UNSUPPORTED_VALUE   "UnsupportedValue"
 #define DFCI_STR_CERT_NOT_AVAILABLE  "No Cert information available"
 
-
 #endif // __DFCI_SETTING_STRINGS_H__

--- a/DfciPkg/Include/DfciSystemSettingStrings.h
+++ b/DfciPkg/Include/DfciSystemSettingStrings.h
@@ -1,0 +1,61 @@
+/** @file
+DfciSystemSettingStrings.h
+
+These are the setting strings.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __DFCI_SETTING_STRINGS_H__
+#define __DFCI_SETTING_STRINGS_H__
+
+//
+// DFCI Setting Type
+//
+#define DFCI_STR_SETTING_TYPE_ENABLE             "ENABLE/DISABLE TYPE"
+#define DFCI_STR_SETTING_TYPE_SECUREBOOTKEYENUM  "SECURE BOOT KEY ENUM TYPE"
+#define DFCI_STR_SETTING_TYPE_PASSWORD           "PASSWORD TYPE"
+#define DFCI_STR_SETTING_TYPE_USBPORTENUM        "USB PORT STATE TYPE"
+#define DFCI_STR_SETTING_TYPE_STRING             "STRING TYPE"
+#define DFCI_STR_SETTING_TYPE_BINARY             "BINARY TYPE"
+#define DFCI_STR_SETTING_TYPE_CERT               "CERT TYPE"
+
+//
+// Enable/Disable
+//
+#define DFCI_STR_ENABLED   "Enabled"
+#define DFCI_STR_DISABLED  "Disabled"
+
+//
+// Secure Boot Key
+//
+#define DFCI_STR_SECURE_BOOT_KEY_MS_ONLY       "MsOnly"
+#define DFCI_STR_SECURE_BOOT_KEY_MS_3RD_PARTY  "MsPlus3rdParty"
+#define DFCI_STR_SECURE_BOOT_KEY_NONE          "None"
+#define DFCI_STR_SECURE_BOOT_KEY_CUSTOM        "Custom"
+
+//
+// System Password
+//
+#define DFCI_STR_SYSTEM_PASSWORD_SET      "System Password Set"
+#define DFCI_STR_SYSTEM_PASSWORD_NOT_SET  "No System Password"
+
+//
+// USB Port State
+//
+#define DFCI_STR_USB_PORT_ENABLED        "UsbPortEnabled"
+#define DFCI_STR_USB_PORT_HW_DISABLED    "UsbPortHwDisabled"
+#define DFCI_STR_USB_PORT_DATA_DISABLED  "UsbPortDataDisabled"
+#define DFCI_STR_USB_PORT_AUTHENTICATED  "UsbPortAuthenticated"
+
+//
+// Misc
+//
+#define DFCI_STR_INCONSISTENT        "Inconsistent"
+#define DFCI_STR_UNKNOWN             "Unknown"
+#define DFCI_STR_UNSUPPORTED_VALUE   "UnsupportedValue"
+#define DRCI_STR_CERT_NOT_AVAILABLE  "No Cert information available"
+
+#endif // __DFCI_SETTING_STRINGS_H__

--- a/DfciPkg/SettingsManager/SettingsManager.h
+++ b/DfciPkg/SettingsManager/SettingsManager.h
@@ -15,6 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <XmlTypes.h>
 #include <DfciSystemSettingTypes.h>
+#include <DfciSystemSettingStrings.h>
 
 #include <Guid/DfciInternalVariableGuid.h>
 #include <Guid/DfciDeviceIdVariables.h>

--- a/DfciPkg/SettingsManager/SettingsManagerCurrentSettingXml.c
+++ b/DfciPkg/SettingsManager/SettingsManagerCurrentSettingXml.c
@@ -175,19 +175,19 @@ CreateXmlStringFromCurrentSettings (
         case DFCI_SETTING_TYPE_ENABLE:
           switch (Value) {
             case ENABLE_FALSE:
-              ReturnValue = "Disabled";
+              ReturnValue = DFCI_STR_DISABLED;
               break;
 
             case ENABLE_TRUE:
-              ReturnValue = "Enabled";
+              ReturnValue = DFCI_STR_ENABLED;
               break;
 
             case ENABLE_INCONSISTENT:
-              ReturnValue = "Inconsistent";
+              ReturnValue = DFCI_STR_INCONSISTENT;
               break;
 
             default:
-              ReturnValue = "Unknown";
+              ReturnValue = DFCI_STR_UNKNOWN;
               break;
           }
 
@@ -196,27 +196,27 @@ CreateXmlStringFromCurrentSettings (
         case DFCI_SETTING_TYPE_USBPORTENUM:
           switch (Value) {
             case DfciUsbPortHwDisabled:
-              ReturnValue = "UsbPortHwDisabled";
+              ReturnValue = DFCI_STR_USB_PORT_HW_DISABLED;
               break;
 
             case DfciUsbPortEnabled:
-              ReturnValue = "UsbPortEnabled";
+              ReturnValue = DFCI_STR_USB_PORT_ENABLED;
               break;
 
             case DfciUsbPortDataDisabled:
-              ReturnValue = "UsbPortDataDisabled";
+              ReturnValue = DFCI_STR_USB_PORT_DATA_DISABLED;
               break;
 
             case DfciUsbPortAuthenticated:
-              ReturnValue = "UsbPortAuthenticated";
+              ReturnValue = DFCI_STR_USB_PORT_AUTHENTICATED;
               break;
 
             case ENABLE_INCONSISTENT:
-              ReturnValue = "Inconsistent";
+              ReturnValue = DFCI_STR_INCONSISTENT;
               break;
 
             default:
-              ReturnValue = "UnsupportedValue";
+              ReturnValue = DFCI_STR_UNSUPPORTED_VALUE;
               break;
           }
 
@@ -224,7 +224,7 @@ CreateXmlStringFromCurrentSettings (
 
         default:
           DEBUG ((DEBUG_ERROR, "%a: Group entries for type(%d) not supported\n", __FUNCTION__, GroupType));
-          ReturnValue = "UnsupportedValue";
+          ReturnValue = DFCI_STR_UNSUPPORTED_VALUE;
           break;
       }
     }

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -629,7 +629,8 @@ ProviderValueAsAscii (
 
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Unable to get strings from the certificate\n"));
-        ValueSize = sizeof (DRCI_STR_CERT_NOT_AVAILABLE);
+        ValueSize = sizeof (DFCI_STR_CERT_NOT_AVAILABLE);
+
         Value     = AllocatePool (ValueSize);
         if (NULL != Value) {
           AsciiStrnCpyS (Value, ValueSize, DFCI_STR_CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -14,8 +14,7 @@ LIST_ENTRY  mProviderList = INITIALIZE_LIST_HEAD_VARIABLE (mProviderList); // li
 
 static DFCI_AUTHENTICATION_PROTOCOL  *mAuthenticationProtocol = NULL;
 
-#define CERT_STRING_SIZE    (200)
-#define CERT_NOT_AVAILABLE  "No Cert information available"
+#define CERT_STRING_SIZE  (200)
 
 /**
 Helper function to return the string describing the type enum
@@ -27,28 +26,28 @@ ProviderTypeAsAscii (
 {
   switch (Type) {
     case DFCI_SETTING_TYPE_ENABLE:
-      return "ENABLE/DISABLE TYPE";
+      return DFCI_STR_SETTING_TYPE_ENABLE;
 
     case DFCI_SETTING_TYPE_SECUREBOOTKEYENUM:
-      return "SECURE BOOT KEY ENUM TYPE";
+      return DFCI_STR_SETTING_TYPE_SECUREBOOTKEYENUM;
 
     case DFCI_SETTING_TYPE_PASSWORD:
-      return "PASSWORD TYPE";
+      return DFCI_STR_SETTING_TYPE_PASSWORD;
 
     case DFCI_SETTING_TYPE_USBPORTENUM:
-      return "USB PORT STATE TYPE";
+      return DFCI_STR_SETTING_TYPE_USBPORTENUM;
 
     case DFCI_SETTING_TYPE_STRING:
-      return "STRING TYPE";
+      return DFCI_STR_SETTING_TYPE_STRING;
 
     case DFCI_SETTING_TYPE_BINARY:
-      return "BINARY TYPE";
+      return DFCI_STR_SETTING_TYPE_BINARY;
 
     case DFCI_SETTING_TYPE_CERT:
-      return "CERT TYPE";
+      return DFCI_STR_SETTING_TYPE_CERT;
 
     default:
-      return "Unknown";
+      return DFCI_STR_UNKNOWN;
       break;
   }
 }
@@ -173,12 +172,12 @@ SetProviderValueFromAscii (
     case DFCI_SETTING_TYPE_ENABLE:
       // convert to BOOLEAN
 
-      if (AsciiStrCmp (Value, "Enabled") == 0) {
+      if (AsciiStrCmp (Value, DFCI_STR_ENABLED) == 0) {
         v = TRUE;
-        DEBUG ((DEBUG_INFO, "Setting to Enabled\n"));
-      } else if (AsciiStrCmp (Value, "Disabled") == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
+      } else if (AsciiStrCmp (Value, DFCI_STR_DISABLED) == 0) {
         v = FALSE;
-        DEBUG ((DEBUG_INFO, "Setting to Disabled\n"));
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
       } else {
         DEBUG ((DEBUG_ERROR, "Invalid Settings Ascii Value for Type Enable (%a)\n", Value));
         return EFI_INVALID_PARAMETER;
@@ -189,14 +188,14 @@ SetProviderValueFromAscii (
       break;
 
     case DFCI_SETTING_TYPE_SECUREBOOTKEYENUM:
-      if (AsciiStrCmp (Value, "MsOnly") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to MsOnly\n"));
+      if (AsciiStrCmp (Value, DFCI_STR_SECURE_BOOT_KEY_MS_ONLY) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         b = 0;
-      } else if (AsciiStrCmp (Value, "MsPlus3rdParty") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to MsPlus3rdParty\n"));
+      } else if (AsciiStrCmp (Value, DFCI_STR_SECURE_BOOT_KEY_MS_3RD_PARTY) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         b = 1;
-      } else if (AsciiStrCmp (Value, "None") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to None\n"));
+      } else if (AsciiStrCmp (Value, DFCI_STR_SECURE_BOOT_KEY_NONE) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         b = 2;
       } else {
         DEBUG ((DEBUG_INFO, "Invalid Secure Boot Key Enum Setting. %a\n", Value));
@@ -251,17 +250,17 @@ SetProviderValueFromAscii (
       break;
 
     case DFCI_SETTING_TYPE_USBPORTENUM:
-      if (AsciiStrCmp (Value, "UsbPortEnabled") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to Usb Port Enabled\n"));
+      if (AsciiStrCmp (Value, DFCI_STR_USB_PORT_ENABLED) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         UsbPortState = DfciUsbPortEnabled;
-      } else if (AsciiStrCmp (Value, "UsbPortHwDisabled") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to Usb Port HW Disabled\n"));
+      } else if (AsciiStrCmp (Value, DFCI_STR_USB_PORT_HW_DISABLED) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         UsbPortState = DfciUsbPortHwDisabled;
-      } else if (AsciiStrCmp (Value, "UsbPortDataDisabled") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to Usb Data Disabled\n"));
+      } else if (AsciiStrCmp (Value, DFCI_STR_USB_PORT_DATA_DISABLED) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         UsbPortState = DfciUsbPortDataDisabled;
-      } else if (AsciiStrCmp (Value, "UsbPortAuthenticated") == 0) {
-        DEBUG ((DEBUG_INFO, "Setting to Usb Authenticated\n"));
+      } else if (AsciiStrCmp (Value, DFCI_STR_USB_PORT_AUTHENTICATED) == 0) {
+        DEBUG ((DEBUG_INFO, "Setting to %a\n", Value));
         UsbPortState = DfciUsbPortAuthenticated;
       } else {
         DEBUG ((DEBUG_INFO, "Invalid or unsupported Usb Port Setting. %a\n", Value));
@@ -373,15 +372,14 @@ ProviderValueAsAscii (
       }
 
       if (v == ENABLE_INCONSISTENT) {
-        AsciiString = "Inconsistent";
+        AsciiString = DFCI_STR_INCONSISTENT;
       } else if (v) {
-        AsciiString = "Enabled";
+        AsciiString = DFCI_STR_ENABLED;
       } else {
-        AsciiString = "Disabled";
+        AsciiString = DFCI_STR_DISABLED;
       }
 
       ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
-
 
       Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {
@@ -407,14 +405,14 @@ ProviderValueAsAscii (
       }
 
       if (b == 0) {
-        AsciiString = "MsOnly";
+        AsciiString = DFCI_STR_SECURE_BOOT_KEY_MS_ONLY;
       } else if (b == 1) {
-        AsciiString = "MsPlus3rdParty";
+        AsciiString = DFCI_STR_SECURE_BOOT_KEY_MS_3RD_PARTY;
       } else if (b == 3) {
         // This is a special case.  Only supported as output.
-        AsciiString = "Custom";
+        AsciiString = DFCI_STR_SECURE_BOOT_KEY_CUSTOM;
       } else {
-        AsciiString = "None";
+        AsciiString = DFCI_STR_SECURE_BOOT_KEY_NONE;
       }
 
       ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
@@ -443,9 +441,9 @@ ProviderValueAsAscii (
       }
 
       if (v) {
-        AsciiString = "System Password Set";
+        AsciiString = DFCI_STR_SYSTEM_PASSWORD_SET;
       } else {
-        AsciiString = "No System Password";
+        AsciiString = DFCI_STR_SYSTEM_PASSWORD_NOT_SET;
       }
 
       ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
@@ -474,17 +472,17 @@ ProviderValueAsAscii (
       }
 
       if (b == DfciUsbPortHwDisabled) {
-        AsciiString = "UsbPortHwDisabled";
+        AsciiString = DFCI_STR_USB_PORT_HW_DISABLED;
       } else if (b == DfciUsbPortEnabled) {
-        AsciiString = "UsbPortEnabled";
+        AsciiString = DFCI_STR_USB_PORT_ENABLED;
       } else if (b == DfciUsbPortDataDisabled) {
-        AsciiString = "UsbPortDataDisabled";
+        AsciiString = DFCI_STR_USB_PORT_DATA_DISABLED;
       } else if (b == DfciUsbPortAuthenticated) {
-        AsciiString = "UsbPortAuthenticated";
+        AsciiString = DFCI_STR_USB_PORT_AUTHENTICATED;
       } else if (b == ENABLE_INCONSISTENT) {
-        AsciiString = "Inconsistent";
+        AsciiString = DFCI_STR_INCONSISTENT;
       } else {
-        AsciiString = "UnsupportedValue";
+        AsciiString = DFCI_STR_UNSUPPORTED_VALUE;
       }
 
       ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
@@ -631,10 +629,10 @@ ProviderValueAsAscii (
 
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Unable to get strings from the certificate\n"));
-        ValueSize = sizeof (CERT_NOT_AVAILABLE);
+        ValueSize = sizeof (DRCI_STR_CERT_NOT_AVAILABLE);
         Value     = AllocatePool (ValueSize);
         if (NULL != Value) {
-          AsciiStrnCpyS (Value, ValueSize, CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));
+          AsciiStrnCpyS (Value, ValueSize, DRCI_STR_CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));
         }
       }
 

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -448,7 +448,7 @@ ProviderValueAsAscii (
         AsciiString = "No System Password";
       }
 
-      ValueSize = AsciiStrLen (AsciiString) + 1;
+      ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
 
       Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -631,10 +631,9 @@ ProviderValueAsAscii (
         DEBUG ((DEBUG_ERROR, "Unable to get strings from the certificate\n"));
         ValueSize = sizeof (DFCI_STR_CERT_NOT_AVAILABLE);
 
-        Value     = AllocatePool (ValueSize);
+        Value = AllocatePool (ValueSize);
         if (NULL != Value) {
           AsciiStrnCpyS (Value, ValueSize, DFCI_STR_CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));
-
         }
       }
 

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -332,11 +332,6 @@ SetProviderValueFromAscii (
   return Status;
 }
 
-#define ENABLED_STRING_SIZE                (13)
-#define SECURE_BOOT_ENUM_STRING_SIZE       (20)
-#define SYSTEM_PASSWORD_STATE_STRING_SIZE  (30)
-#define USB_PORT_STATE_STRING_SIZE         (21)
-
 /**
 Helper function to Print out the Value as Ascii text.
 NOTE: -- This must match the XML format
@@ -355,7 +350,8 @@ ProviderValueAsAscii (
   )
 {
   EFI_STATUS  Status;
-  CHAR8       *Value = NULL;
+  CHAR8       *Value       = NULL;
+  CHAR8       *AsciiString = NULL;
   UINTN       AsciiSize;
   UINT8       *Buffer;
   BOOLEAN     v = FALSE; // Boolean Types
@@ -376,19 +372,23 @@ ProviderValueAsAscii (
         break;
       }
 
-      Value = AllocateZeroPool (ENABLED_STRING_SIZE);
+      if (v == ENABLE_INCONSISTENT) {
+        AsciiString = "Inconsistent";
+      } else if (v) {
+        AsciiString = "Enabled";
+      } else {
+        AsciiString = "Disabled";
+      }
+
+      ValueSize = AsciiStrLen (AsciiString) + 1;
+
+      Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {
         DEBUG ((DEBUG_ERROR, "Failed - Couldn't allocate for string. \n"));
         break;
       }
 
-      if (v == ENABLE_INCONSISTENT) {
-        AsciiStrCpyS (Value, ENABLED_STRING_SIZE, "Inconsistent");
-      } else if (v) {
-        AsciiStrCpyS (Value, ENABLED_STRING_SIZE, "Enabled");
-      } else {
-        AsciiStrCpyS (Value, ENABLED_STRING_SIZE, "Disabled");
-      }
+      AsciiStrCpyS (Value, ValueSize, AsciiString);
 
       break;
 
@@ -405,22 +405,26 @@ ProviderValueAsAscii (
         break;
       }
 
-      Value = AllocateZeroPool (SECURE_BOOT_ENUM_STRING_SIZE);
+      if (b == 0) {
+        AsciiString = "MsOnly";
+      } else if (b == 1) {
+        AsciiString = "MsPlus3rdParty";
+      } else if (b == 3) {
+        // This is a special case.  Only supported as output.
+        AsciiString = "Custom";
+      } else {
+        AsciiString = "None";
+      }
+
+      ValueSize = AsciiStrLen (AsciiString) + 1;
+
+      Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {
         DEBUG ((DEBUG_ERROR, "Failed - Couldn't allocate for string. \n"));
         break;
       }
 
-      if (b == 0) {
-        AsciiStrCpyS (Value, SECURE_BOOT_ENUM_STRING_SIZE, "MsOnly");
-      } else if (b == 1) {
-        AsciiStrCpyS (Value, SECURE_BOOT_ENUM_STRING_SIZE, "MsPlus3rdParty");
-      } else if (b == 3) {
-        // This is a special case.  Only supported as output.
-        AsciiStrCpyS (Value, SECURE_BOOT_ENUM_STRING_SIZE, "Custom");
-      } else {
-        AsciiStrCpyS (Value, SECURE_BOOT_ENUM_STRING_SIZE, "None");
-      }
+      AsciiStrCpyS (Value, ValueSize, AsciiString);
 
       break;
 
@@ -437,17 +441,21 @@ ProviderValueAsAscii (
         break;
       }
 
-      Value = AllocateZeroPool (SYSTEM_PASSWORD_STATE_STRING_SIZE);
+      if (v) {
+        AsciiString = "System Password Set";
+      } else {
+        AsciiString = "No System Password";
+      }
+
+      ValueSize = AsciiStrLen (AsciiString) + 1;
+
+      Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {
         DEBUG ((DEBUG_ERROR, "Failed - Couldn't allocate for string. \n"));
         break;
       }
 
-      if (v) {
-        AsciiStrCpyS (Value, SYSTEM_PASSWORD_STATE_STRING_SIZE, "System Password Set");
-      } else {
-        AsciiStrCpyS (Value, SYSTEM_PASSWORD_STATE_STRING_SIZE, "No System Password");
-      }
+      AsciiStrCpyS (Value, ValueSize, AsciiString);
 
       break;
 
@@ -464,25 +472,29 @@ ProviderValueAsAscii (
         break;
       }
 
-      Value = AllocateZeroPool (USB_PORT_STATE_STRING_SIZE);
+      if (b == DfciUsbPortHwDisabled) {
+        AsciiString = "UsbPortHwDisabled";
+      } else if (b == DfciUsbPortEnabled) {
+        AsciiString = "UsbPortEnabled";
+      } else if (b == DfciUsbPortDataDisabled) {
+        AsciiString = "UsbPortDataDisabled";
+      } else if (b == DfciUsbPortAuthenticated) {
+        AsciiString = "UsbPortAuthenticated";
+      } else if (b == ENABLE_INCONSISTENT) {
+        AsciiString = "Inconsistent";
+      } else {
+        AsciiString = "UnsupportedValue";
+      }
+
+      ValueSize = AsciiStrLen (AsciiString) + 1;
+
+      Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {
         DEBUG ((DEBUG_ERROR, "Failed - Couldn't allocate for string. \n"));
         break;
       }
 
-      if (b == DfciUsbPortHwDisabled) {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "UsbPortHwDisabled");
-      } else if (b == DfciUsbPortEnabled) {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "UsbPortEnabled");
-      } else if (b == DfciUsbPortDataDisabled) {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "UsbPortDataDisabled");
-      } else if (b == DfciUsbPortAuthenticated) {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "UsbPortAuthenticated");
-      } else if (b == ENABLE_INCONSISTENT) {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "Inconsistent");
-      } else {
-        AsciiStrCpyS (Value, USB_PORT_STATE_STRING_SIZE, "UnsupportedValue");
-      }
+      AsciiStrCpyS (Value, ValueSize, AsciiString);
 
       break;
 
@@ -501,7 +513,7 @@ ProviderValueAsAscii (
         break;
       }
 
-      if (0 == ValueSize ) {
+      if (0 == ValueSize) {
         break;                   // Return NULL for Value silently
       }
 
@@ -555,7 +567,7 @@ ProviderValueAsAscii (
         break;
       }
 
-      if (0 == ValueSize ) {
+      if (0 == ValueSize) {
         ValueSize = sizeof ("");
         Value     = AllocatePool (ValueSize);
         if (NULL != Value) {
@@ -643,7 +655,7 @@ ProviderValueAsAscii (
         break;
       }
 
-      if (0 == ValueSize ) {
+      if (0 == ValueSize) {
         break;                     // Return NULL for Value silently
       }
 

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -487,7 +487,7 @@ ProviderValueAsAscii (
         AsciiString = "UnsupportedValue";
       }
 
-      ValueSize = AsciiStrLen (AsciiString) + 1;
+      ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
 
       Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -380,7 +380,8 @@ ProviderValueAsAscii (
         AsciiString = "Disabled";
       }
 
-      ValueSize = AsciiStrLen (AsciiString) + 1;
+      ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
+
 
       Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -632,7 +632,8 @@ ProviderValueAsAscii (
         ValueSize = sizeof (DRCI_STR_CERT_NOT_AVAILABLE);
         Value     = AllocatePool (ValueSize);
         if (NULL != Value) {
-          AsciiStrnCpyS (Value, ValueSize, DRCI_STR_CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));
+          AsciiStrnCpyS (Value, ValueSize, DFCI_STR_CERT_NOT_AVAILABLE, ValueSize-sizeof (CHAR8));
+
         }
       }
 

--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -417,7 +417,7 @@ ProviderValueAsAscii (
         AsciiString = "None";
       }
 
-      ValueSize = AsciiStrLen (AsciiString) + 1;
+      ValueSize = AsciiStrnSizeS (AsciiString, DFCI_MAX_ID_LEN);
 
       Value = AllocateZeroPool (ValueSize);
       if (Value == NULL) {


### PR DESCRIPTION
## Description

Refactor ProviderValueAsAscii() and remove following macros to make it can allocate buffer with right size for each setting.
Fix https://github.com/microsoft/mu_feature_dfci/issues/43

```
#define ENABLED_STRING_SIZE                (9)
#define ASSET_TAG_STRING_MAX_SIZE          (22)
#define SECURE_BOOT_ENUM_STRING_SIZE       (20)
#define SYSTEM_PASSWORD_STATE_STRING_SIZE  (30)
#define USB_PORT_STATE_STRING_SIZE         (20)
```

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with SEMM tool. No regression seen.

## Integration Instructions

N/A
