### PR TITLE
Corrected use of BOOLEAN for values other than TRUE and FALSE

### DIFF
--- a/DfciPkg/SettingsManager/SettingsManagerProvider.c
+++ b/DfciPkg/SettingsManager/SettingsManagerProvider.c
@@ -359,11 +359,11 @@ ProviderValueAsAscii (
 
   switch (Provider->Type) {
     case DFCI_SETTING_TYPE_ENABLE:
-      ValueSize = sizeof (v);
+      ValueSize = sizeof (b);
       if (Current) {
-        Status = Provider->GetSettingValue (Provider, &ValueSize, &v);
+        Status = Provider->GetSettingValue (Provider, &ValueSize, &b);
       } else {
-        Status = Provider->GetDefaultValue (Provider, &ValueSize, &v);
+        Status = Provider->GetDefaultValue (Provider, &ValueSize, &b);
       }
 
       if (EFI_ERROR (Status)) {
@@ -371,9 +371,9 @@ ProviderValueAsAscii (
         break;
       }
 
-      if (v == ENABLE_INCONSISTENT) {
+      if (b == ENABLE_INCONSISTENT) {
         AsciiString = DFCI_STR_INCONSISTENT;
-      } else if (v) {
+      } else if (b) {
         AsciiString = DFCI_STR_ENABLED;
       } else {
         AsciiString = DFCI_STR_DISABLED;


### PR DESCRIPTION
## Description
Uefi coding standard states that BOOLEANs should only contain TRUE or FALSE. 

Corrected area of code that are using a BOOLEAN to store a UINT8 value.

Functionality is not affected because of how BOOLEAN is declared in ProcessorBind.h. (BOOLEAN and UINT8 are the same type)

Fixes #45 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Ran Local CI

## Integration Instructions
N/A