### PR TITLE
Revert invalid change which breaks DFCI Refresh from network from "Add Test requirement for using local Refresh from Network server. (#3)"  577c811

### DIFF
--- a/DfciPkg/Application/DfciMenu/DfciRequest.c
+++ b/DfciPkg/Application/DfciMenu/DfciRequest.c
@@ -1638,6 +1638,14 @@ DfciMainLogic (
   *DoneProcessing            = FALSE;
   NetworkRequest->LogicState = DFCI_PRE_BOOTSTRAP;
 
+  //
+  // Step 1. Ping server with Bootstrap URL provided in DFCI settings
+  //
+  Status = BuildJsonBootstrapRequest (NetworkRequest);
+  if (EFI_ERROR (Status)) {
+    goto MAIN_CLEANUP;
+  }
+
   Status = ProcessAsyncRequest (
              NetworkRequest,
              NetworkRequest->HttpRequest.BootstrapUrl,


### PR DESCRIPTION
Resolve issue where DFCI network refresh returns error code 400: bad request.  


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?


## How This Was Tested

Code inspection.  Additional testing will be done by product teams.

