### PR TITLE
Make DFCI Lock Var Runtime accessible

### DIFF
--- a/DfciPkg/Include/Guid/DfciInternalVariableGuid.h
+++ b/DfciPkg/Include/Guid/DfciInternalVariableGuid.h
@@ -25,7 +25,7 @@ extern EFI_GUID  gDfciInternalVariableGuid;
 // Dfci Lock Variable.
 //
 #define DFCI_LOCK_VAR_NAME        L"_DLCK"
-#define DFCI_LOCK_VAR_ATTRIBUTES  EFI_VARIABLE_BOOTSERVICE_ACCESS
+#define DFCI_LOCK_VAR_ATTRIBUTES  (EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS)
 #define DFCI_LOCK_VAR_SIZE        sizeof (UINT8)
 
 extern EFI_GUID  gDfciLockVariableGuid;


### PR DESCRIPTION
## Description

Due to how Variable Locking works the lock variable should be runtime accessible.  


- [x] Impacts functionality?
- [x] Impacts security?


## How This Was Tested

Code inspection

## Integration Instructions

NA
