### PR TITLE
Fix duplicate name error when adding second firewall rule

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/DeviceUnderTest/SetupDUT.ps1
+++ b/DfciPkg/UnitTests/DfciTests/DeviceUnderTest/SetupDUT.ps1
@@ -81,7 +81,7 @@ New-NetFirewallRule -Name Allow_Ping -DisplayName “Allow Ping”  -Description
 
 # allow robotserver port 8270 and 8271
 New-NetFirewallRule -Name Allow_robotserver -DisplayName “Allow Python Robot server 8270” -Protocol TCP -LocalPort 8270 -Description “PyRobot server” -Enabled True -Profile Any -Action Allow
-New-NetFirewallRule -Name Allow_robotserver -DisplayName “Allow Python Robot server 8271” -Protocol TCP -LocalPort 8271 -Description “PyRobot server” -Enabled True -Profile Any -Action Allow
+New-NetFirewallRule -Name Allow_robotserver2 -DisplayName “Allow Python Robot server 8271” -Protocol TCP -LocalPort 8271 -Description “PyRobot server” -Enabled True -Profile Any -Action Allow
 
 ##set up task scheduler to run robot server
 Register-ScheduledTask -Xml (get-content 'PyRobotServer.xml' | out-string) -TaskName "PyRobot Server" –Force


### PR DESCRIPTION
## Description

Originally tested on a system where the firewall was disabled, so the missing firewall entry error was not observed.  Fixes #74 

- [x] Impacts functionality?

- [ ] Impacts security?

- [ ] Breaking change?

- [x] Includes tests?
  - Changes the setup script
- [ ] Includes documentation?

## How This Was Tested

Tested configuring a Windows Guest running in a QemuQ35Pkg VM.

## Integration Instructions

N/A
