### PR TITLE
Remove references to a function removed long ago

### DIFF
--- a/DfciPkg/IdentityAndAuthManager/AuthManagerProvision.c
+++ b/DfciPkg/IdentityAndAuthManager/AuthManagerProvision.c
@@ -617,7 +617,7 @@ ApplyNewIdentityPacket (
                );
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "DfciUiGetAnswerFromUser failed %r\n", Status));
+      DEBUG ((DEBUG_ERROR, "LocalGetAnswerFromUser failed %r\n", Status));
       if (Status == EFI_NOT_READY) {
         Data->State      = DFCI_PACKET_STATE_DATA_SYSTEM_ERROR;
         Data->StatusCode = EFI_NOT_READY;
@@ -634,7 +634,7 @@ ApplyNewIdentityPacket (
   }
 
   if (Data->State != DFCI_PACKET_STATE_DATA_USER_APPROVED) {
-    DEBUG ((DEBUG_ERROR, "DfciUiGetAnswerFromUser - User Rejected Change\n"));
+    DEBUG ((DEBUG_ERROR, "LocalGetAnswerFromUser - User Rejected Change\n"));
     goto CLEANUP;
   }
 

--- a/DfciPkg/Library/DfciUiSupportLibNull/DfciUiSupportLibNull.c
+++ b/DfciPkg/Library/DfciUiSupportLibNull/DfciUiSupportLibNull.c
@@ -106,35 +106,6 @@ DfciUiDisplayAuthDialog (
 }
 
 /**
-  This routine is called by DFCI to prompt a local user to confirm certificate
-  provisioning operations.
-
-  @param  AuthMgrProtocol        Supplies a pointer to the authentication
-                                 manager protocol.
-  @param  TrustedCert            Supplies a pointer to a trusted certificate.
-  @param  TrustedCertSize        Supplies the size in bytes of the trusted
-                                 certificate.
-  @param  AuthToken              Supplies a pointer that will receive an
-                                 authentication token.
-
-  @return EFI_NOT_READY          Indicates that UI components are not available.
-  @return EFI_ACCESS_DENIED      The user rejected the operation.
-  @return EFI_SUCCESS            The user approved the operation.
-
-**/
-EFI_STATUS
-EFIAPI
-DfciUiGetAnswerFromUser (
-  DFCI_AUTHENTICATION_PROTOCOL  *AuthMgrProtocol,
-  UINT8                         *TrustedCert,
-  UINT16                        TrustedCertSize,
-  OUT DFCI_AUTH_TOKEN           *AuthToken
-  )
-{
-  return EFI_SUCCESS;
-}
-
-/**
     DfciUiExitSecurityBoundary
 
     UEFI that support locked settings variables can lock those


### PR DESCRIPTION
## Description

Code comments and the library DfciUiSupportLibNull reference a function no longer used.  This removes the dead code from the NULL library, and updates comments in the active code. Fixes #75

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?

- [ ] Impacts security?

- [ ] Breaking change?

- [ ] Includes tests?

- [ ] Includes documentation?


## How This Was Tested

Not tested

## Integration Instructions

N/A
