### PR TITLE
DfciV1SupportLibNull: Assign actual library class

### DIFF
--- a/DfciPkg/Library/DfciV1SupportLibNull/DfciV1SupportLibNull.inf
+++ b/DfciPkg/Library/DfciV1SupportLibNull/DfciV1SupportLibNull.inf
@@ -10,11 +10,11 @@
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = DfciSupportLib
+  BASE_NAME                      = BaseDfciV1SupportLibNull
   FILE_GUID                      = eaa7ea2a-bee2-4c30-986a-3c529ef1b01f
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DfciSupportLib
+  LIBRARY_CLASS                  = DfciV1SupportLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -26,21 +26,12 @@
   DfciV1SupportLibNull.c
 
 [Packages]
-  DfciPkg/DfciPkg.dec
   MdePkg/MdePkg.dec
+  DfciPkg/DfciPkg.dec
 
 [LibraryClasses]
   BaseLib
   DebugLib
 
-[Guids]
-
-[Protocols]
-
-[FeaturePcd]
-
-[Pcd]
-
 [Depex]
   TRUE
-


### PR DESCRIPTION
## Description

The library class is currently `DfciSupportLib` in the INF file. This
name is not used anywhere else including consuming code and
documenation. Therefore, some packages have used the library class
name used elsewhere (`DfciV1SupportLibNull`) but that may give a
warning since the library class does not match the INF.

This changes updates the INF so the name is consistent.

There's also minor other cleanup:

- Fix `BASE_NAME` so it accurately identifies the instance
- Move `MdePkg.dec` to the beginning of the package order to allow
  more specific definitions to override generic ones in `MdePkg`.
- Remove empty sections cluttering the file.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

DfciPkg build and build of packages dependent on the library class.

## Integration Instructions

If `DfciSupportLib` was being used before to reference this library class instance
in a package, update it to `DfciV1SupportLib`.