### PR TITLE
Fix invalid access of NewRecoveryChallenge when memory allocation fails

### DIFF
--- a/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.c
+++ b/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.c
@@ -76,8 +76,9 @@ GetRecoveryChallenge (
   // Allocate the buffer...
   if (!EFI_ERROR (Status)) {
     NewChallenge = AllocatePool (sizeof (DFCI_RECOVERY_CHALLENGE) + DFCI_MULTI_STRING_MAX_SIZE);
+    // Exit if we ran out of resources
     if (NewChallenge == NULL) {
-      Status = EFI_OUT_OF_RESOURCES;
+      return EFI_OUT_OF_RESOURCES;
     }
   }
 


### PR DESCRIPTION
## Description
If memory allocation for the NewChallenge variable should not be used. It will result in Invalid access at the following line.
  NewChallenge->SerialNumber = 0;

With this change if memory allocation for the NewChallenge variable fails, EFI_OUT_OF_RESOURCES is returned


- [ ] Impacts functionality? No
- [ ] Impacts security? No
- [ ] Breaking change? No
- [ ] Includes tests? No
- [ ] Includes documentation? No

## How This Was Tested
Build passes with this change

## Integration Instructions
N/A