### PR TITLE
Fixes the Deprecation Warning for return in Robot Framework

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/Support/Robot/DFCI_Shared_Keywords.robot
+++ b/DfciPkg/UnitTests/DfciTests/Support/Robot/DFCI_Shared_Keywords.robot
@@ -61,21 +61,21 @@ Get System Under Test SerialNumber
     ${Value}=   Run PowerShell And Return Output   ${CMD_SERIALNUMBER_TYPE1}
     Should Be True  '${Value}' != 'Error'
     Should Be True  '${Value}' != ''
-    [Return]        ${Value}
+    RETURN        ${Value}
 
 
 Get System Under Test Manufacturer
     ${Value}=   Run PowerShell And Return Output   ${CMD_MFG}
     Should Be True  '${Value}' != 'Error'
     Should Be True  '${Value}' != ''
-    [Return]        ${Value}
+    RETURN        ${Value}
 
 
 Get System Under Test ProductName
     ${Value}=   Run PowerShell And Return Output   ${CMD_MODEL}
     Should Be True  '${Value}' != 'Error'
     Should Be True  '${Value}' != ''
-    [Return]        ${Value}
+    RETURN        ${Value}
 
 
 ############################################################
@@ -300,7 +300,7 @@ Validate Permission Status
 
     Get Payload From Permissions Results  ${binResultFile}  ${xmlResultFile}
     File Should Exist  ${xmlResultFile}
-    [return]  ${xmlResultFile}
+    RETURN  ${xmlResultFile}
 
 
 ############################################################
@@ -335,7 +335,7 @@ Validate Settings Status
 
     Get Payload From Settings Results  ${binResultFile}  ${xmlResultFile}
     Run Keyword If  '${expectedStatus}' == ${STATUS_SUCCESS}  File Should Exist  ${xmlResultFile}
-    [return]  ${xmlResultFile}
+    RETURN  ${xmlResultFile}
 
 
 ########################################################################

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneBadUpdate/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneBadUpdate/run.robot
@@ -72,7 +72,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 *** Test Cases ***

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneEnroll/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneEnroll/run.robot
@@ -73,7 +73,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 *** Test Cases ***

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTunePermissions/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTunePermissions/run.robot
@@ -193,7 +193,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 #------------------------------------------------------------------*

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneRollCerts/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneRollCerts/run.robot
@@ -73,7 +73,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 *** Test Cases ***

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/run.robot
@@ -257,7 +257,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 #------------------------------------------------------------------*

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneUnenroll/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneUnenroll/run.robot
@@ -75,7 +75,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 *** Test Cases ***

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_RefreshServer/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_RefreshServer/run.robot
@@ -74,7 +74,7 @@ Get Response header
     ${good}=  Evaluate  "${value}" != "Not Found"
     Should Be True  ${good}
 
-    [return]  ${value}
+    RETURN  ${value}
 
 
 *** Test Cases ***

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_TPM_DisableEnable/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_TPM_DisableEnable/run.robot
@@ -206,7 +206,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 #------------------------------------------------------------------*

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_UnsignedSettings/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_UnsignedSettings/run.robot
@@ -235,7 +235,7 @@ Get The DFCI Settings
 
     Get and Print Current Settings     ${currentSettingsxmlFile}
 
-    [return]    ${currentIdxmlFile}
+    RETURN    ${currentIdxmlFile}
 
 
 #------------------------------------------------------------------*


### PR DESCRIPTION


## Description

Corrects deprecation warning in Robot Framework

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
  - All tests were updated
- [ ] Includes documentation?

## How This Was Tested

Ran before change - warnings
Ran after change - no warnins

## Integration Instructions

N / A