### PR TITLE
Update DfciUpdate.c to avoid unsigned comparison checking greater than zero

### DIFF
--- a/DfciPkg/Application/DfciMenu/DfciUpdate.c
+++ b/DfciPkg/Application/DfciMenu/DfciUpdate.c
@@ -321,8 +321,7 @@ BuildUsbRequest (
   //  replace the invalid character with an '@'.
   //
   for (i = 0; i < PktNameLen; i++) {
-    if (((PktFileName[i] >= 0x00) &&
-         (PktFileName[i] <= 0x1F)) ||
+    if ((PktFileName[i] <= 0x1F) ||
         (PktFileName[i] == L'\"') ||
         (PktFileName[i] == L'*')  ||
         (PktFileName[i] == L'/')  ||


### PR DESCRIPTION
# Description

Resolve a CodeQL identified issue where an unsigned type was being checked against greater than or equal to zero.  This will always be true and thus provides no value

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Was not tested other than basic CI

## Integration Instructions

NA
