### PR TITLE
DfciPkg/DfciTests: fix refresh server pip failure

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/RefreshServer/Dockerfile
+++ b/DfciPkg/UnitTests/DfciTests/RefreshServer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update \
   && apt install python3 -y \
   && apt install python3-pip -y \
   && rm -rf /var/lib/apt/lists/* \
-  && pip3 install cython cherrypy flask pyOpenSSL
+  && pip3 install --break-system-packages cython cherrypy flask pyOpenSSL
 
 COPY Src/ ${WEB_DIR}/
 WORKDIR ${WEB_DIR}


### PR DESCRIPTION
## Description

Adds a command line switch to a pip command in the dockerfile.  This allows the docker image creation process to pass.

`--break-system-packages` was introduced in pip 23.0.1.

- https://pip.pypa.io/en/stable/news/#v23-0-1

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Built on Windows 10.

## Integration Instructions

N/A

Fixes #234 