### PR TITLE
DfciPkg/DfciTests: remove silicon-specific test

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/DfciSettings.xml
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/DfciSettings.xml
@@ -27,10 +27,6 @@
           <Value>Disabled</Value>
       </Setting>
       <Setting>
-          <Id>Dfci3.ProcessorSMT.Enable</Id>
-          <Value>Disabled</Value>
-      </Setting>
-      <Setting>
           <Id>Dfci3.AssetTag.String</Id>
           <Value>DFCI.LAB.001234</Value>
       </Setting>

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/run.robot
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_InTuneSettings/run.robot
@@ -122,29 +122,23 @@ Initialize lists of tests
 
     # Testcase 3    V3 Set variables
     @{VTEST_03_SET1}=      Create List    Dfci3.OnboardWpbt.Enable      Enabled
-    @{VTEST_03_SET2}=      Create List    Dfci3.ProcessorSMT.Enable     Enabled
 
     @{VTEST_03_CHECK1}=    Create List    Dfci3.OnboardWpbt.Enable      Enabled
-    @{VTEST_03_CHECK2}=    Create List    Dfci3.ProcessorSMT.Enable     Enabled
 
     ${VTEST_03_RESULTS}    Create Dictionary     Dfci3.OnboardWpbt.Enable      ${STATUS_SUCCESS}
-    Set To Dictionary      ${VTEST_03_RESULTS}   Dfci3.ProcessorSMT.Enable     ${STATUS_SUCCESS}
 
-    @{VTEST_03_SETS}=      Create List    ${VTEST_03_SET1}    ${VTEST_03_SET2}
-    @{VTEST_03_CHECKS}=    Create List    ${VTEST_03_CHECK1}    ${VTEST_03_CHECK2}
+    @{VTEST_03_SETS}=      Create List    ${VTEST_03_SET1}
+    @{VTEST_03_CHECKS}=    Create List    ${VTEST_03_CHECK1}
 
     # Testcase 4    V3 Set variables disabled
     @{VTEST_04_SET1}=      Create List    Dfci3.OnboardWpbt.Enable      Disabled
-    @{VTEST_04_SET2}=      Create List    Dfci3.ProcessorSMT.Enable     Disabled
 
     @{VTEST_04_CHECK1}=    Create List    Dfci3.OnboardWpbt.Enable      Disabled
-    @{VTEST_04_CHECK2}=    Create List    Dfci3.ProcessorSMT.Enable     Disabled
 
     ${VTEST_04_RESULTS}    Create Dictionary     Dfci3.OnboardWpbt.Enable      ${STATUS_SUCCESS}
-    Set To Dictionary      ${VTEST_04_RESULTS}   Dfci3.ProcessorSMT.Enable     ${STATUS_SUCCESS}
 
-    @{VTEST_04_SETS}=      Create List    ${VTEST_04_SET1}    ${VTEST_04_SET2}
-    @{VTEST_04_CHECKS}=    Create List    ${VTEST_04_CHECK1}    ${VTEST_04_CHECK2}
+    @{VTEST_04_SETS}=      Create List    ${VTEST_04_SET1}
+    @{VTEST_04_CHECKS}=    Create List    ${VTEST_04_CHECK1}
 
 
     # The full tests are here


### PR DESCRIPTION
## Description

Current base tests DCFI_IntuneSettings use the Dfci3.ProcessorSMT.Enable option for testing DFCI V3 features but this is a silicon specific option that fails on Microsoft AARCH64 platforms as it is not present. Recommend the base tests avoid use of silicon-specific features as these tests will not broadly pass.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] 
## How This Was Tested

DFCI testing on AARCH64 platform.

## Integration Instructions

NA

Fixes #235 