### PR TITLE
DfciPkg/DfciSettings.h: Add new DFCI settings

### DIFF
--- a/DfciPkg/Include/Settings/DfciSettings.h
+++ b/DfciPkg/Include/Settings/DfciSettings.h
@@ -109,6 +109,16 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DFCI_STD_SETTING_ID_V4_ENABLE_WAKE_ON_POWER  "Dfci4.WakeOnPower.Enable"
 
 //
+// Enable or Disable Wake After Power Loss.
+//
+#define DFCI_STD_SETTING_ID_V4_ENABLE_WAKE_AFTER_POWER_LOSS  "Dfci4.WakeAfterPowerLoss.Enable"
+
+//
+// Enable or Disable Wake Always
+//
+#define DFCI_STD_SETTING_ID_V4_ENABLE_WAKE_ALWAYS  "Dfci4.WakeAlways.Enable"
+
+//
 // Enable or Disable the Front Camera(s).
 //
 #define DFCI_STD_SETTING_ID_V4_ENABLE_FRONT_CAMERA  "Dfci4.FrontCamera.Enable"


### PR DESCRIPTION
## Description

Adding DFCI settings for two more power policies: After Power Loss, and Always on. 
- After Power Loss will boot the device back to the previous state before power loss. 
- Always on will always boot the device up to S0. 

The difference between the behaviors of the two modes is `Always On` will boot it up even if power was yanked in the shutdown state. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

