### PR TITLE
Fix for Unsigned setting packets flow

### DIFF
--- a/DfciPkg/SettingsManager/SettingsManagerTransportXml.c
+++ b/DfciPkg/SettingsManager/SettingsManagerTransportXml.c
@@ -449,6 +449,7 @@ ValidateSettingsPacket (
     EndData = &Data->Packet->Hdr.Pkt[Data->PacketSize];
     if (Data->SignedDataLength != Data->PacketSize) {
       DEBUG ((DEBUG_ERROR, "%a - Signed Data in unsigned packet. %d != %d.\n", __FUNCTION__, Data->SignedDataLength, Data->PacketSize));
+      return EFI_COMPROMISED_DATA;
     }
   } else {
     if (Data->SignedDataLength >= Data->PacketSize) {

--- a/DfciPkg/SettingsManager/SettingsManagerTransportXml.c
+++ b/DfciPkg/SettingsManager/SettingsManagerTransportXml.c
@@ -445,6 +445,8 @@ ValidateSettingsPacket (
 
   // == in size means unsigned packet
   if ((UINT8 *)Data->Signature == NULL) {
+    // For unsigned packets, EndData should be the end of the packet
+    EndData = &Data->Packet->Hdr.Pkt[Data->PacketSize];
     if (Data->SignedDataLength != Data->PacketSize) {
       DEBUG ((DEBUG_ERROR, "%a - Signed Data in unsigned packet. %d != %d.\n", __FUNCTION__, Data->SignedDataLength, Data->PacketSize));
     }

--- a/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_UnsignedSettings/GenUsb.bat
+++ b/DfciPkg/UnitTests/DfciTests/TestCases/DFCI_UnsignedSettings/GenUsb.bat
@@ -36,9 +36,9 @@ set OutputFileName=%3_%2_%1.Dfi
 echo Creating  %OutputFileName%
 
 echo python.exe ..\..\Support\Python\GenerateSettingsPacketData.py --Step1Enable --PrepResultFile Unsigned_Settings_apply.bin --XmlFilePath UnsignedSettings.xml --HdrVersion 2 %MfgParm% %ProductParm% %SerialParm%
-python.exe ..\..\Support\Python\GenerateSettingsPacketData.py --Step1Enable --PrepResultFile Unsigned_Settings_apply.bin --XmlFilePath DfciSettings.xml --HdrVersion 2 %MfgParm% %ProductParm% %SerialParm%
+python.exe ..\..\Support\Python\GenerateSettingsPacketData.py --Step1Enable --PrepResultFile Unsigned_Settings_apply.bin --XmlFilePath UnsignedSettings.xml --HdrVersion 2 %MfgParm% %ProductParm% %SerialParm%
 
-..\..\Support\Python\BldDskPkt.py -s Unsigned_Settings_apply.bin -o %OutputFileName%
+python.exe ..\..\Support\Python\BldDskPkt.py -s Unsigned_Settings_apply.bin -o %OutputFileName%
 
 rem erase Unsigned_Settings_apply.bin
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.22.3
+edk2-pytool-library==0.22.5
 edk2-pytool-extensions==0.28.0
 antlr4-python3-runtime==4.13.2
 regex==2024.11.6


### PR DESCRIPTION
## Description

Fix for Unsigned setting packets flow
Unsigned setting packet feature is added a while ago but no one ever used it.
In implementation of this feature I found bugs that will block it from working.
The Genusb.bat that used for creating bins and dfis were updated and the ValidateSettingsPacket
needs to be updated to proper handle unsigned packets which doesn't have a signature and do
need the enddata.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by setting the DfciSettingRequest variable using bin data created from Genusb.bat, settings are configured successfully
and the toggling in frontpage changed as expected.
