### PR TITLE
Fix: Use raw string evaluation to prevent invalid escape sequence warning in signPfx check

### DIFF
--- a/DfciPkg/UnitTests/DfciTests/Support/Robot/DFCI_Shared_Keywords2.robot
+++ b/DfciPkg/UnitTests/DfciTests/Support/Robot/DFCI_Shared_Keywords2.robot
@@ -148,8 +148,9 @@ Create Dfci Permission Package
 Create Dfci Settings Package
     [Arguments]     ${binfile}  ${signPfx}  ${xmlFile}  @{TargetParms}
     File Should Exist   ${xmlFile}
-
-    IF  '${signPfx}' == 'UNSIGNED'
+    
+    ${is_unsigned}=    Evaluate    r"""${signPfx}""" == 'UNSIGNED'
+    IF  ${is_unsigned}
         ${Result}=    Run Process    python.exe    ${GEN_SETTINGS}  --HdrVersion  2  --Step1Enable  --PrepResultFile  ${binfile}  --XmlFilePath  ${xmlFile}  @{TargetParms}
     ELSE
         File Should Exist   ${signPfx}


### PR DESCRIPTION
 Use raw string evaluation to prevent invalid escape sequence warning in signPfx check
 
## Description

Replaced direct string comparison in IF condition with a raw string evaluation to avoid runtime warnings caused by invalid escape sequences.

Details:

The previous implementation:

`IF    "${signPfx}" == "UNSIGNED"`

caused issues when ${signPfx} contained backslashes (e.g., \D), resulting in:
> SyntaxWarning: invalid escape sequence '\D'

This was especially problematic in Azure Devops YAML pipelines, where the warning is treated as a failure due to being written to stderr.

To resolve this, the logic was updated as follows:

```
${is_unsigned}=    Evaluate    r"""${signPfx}""" == "UNSIGNED"
IF    ${is_unsigned}
```
Using a raw string with triple quotes ensures that any backslashes in the value are treated literally, avoiding escape sequence interpretation by Python.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality? No
- [ ] Impacts security? No
- [ ] Breaking change? No
- [ ] Includes tests? No
- [ ] Includes documentation? Np

## How This Was Tested

Tested locally on a physical DUT

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
