### PR TITLE
Add default algo support for ARM platforms

### DIFF
--- a/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.c
+++ b/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.c
@@ -129,6 +129,16 @@ GetRecoveryChallenge (
                                 &NewChallenge->Nonce.Bytes[0]
                                 );
         DEBUG ((DEBUG_VERBOSE, "%a: GetRNG(Hash256) = %r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_INFO, "If non of above available, will use default RNG algorithm\n"));
+        if (EFI_ERROR (Status)) {
+          Status = RngProtocol->GetRNG (
+                                  RngProtocol,
+                                  NULL,
+                                  DFCI_RECOVERY_NONCE_SIZE,
+                                  &NewChallenge->Nonce.Bytes[0]
+                                  );
+          DEBUG ((DEBUG_INFO, "GetRNG's default algorithm - Status = %r\n", Status));
+        }
       }
     }
   }
@@ -273,6 +283,16 @@ EncryptRecoveryChallenge (
                                 &ExtraSeed[0]
                                 );
         DEBUG ((DEBUG_VERBOSE, "%a: GetRNG(Hash256) = %r\n", __FUNCTION__, Status));
+        DEBUG ((DEBUG_INFO, "If non of above available, will use default RNG algorithm\n"));
+        if (EFI_ERROR (Status)) {
+          Status = RngProtocol->GetRNG (
+                                  RngProtocol,
+                                  NULL,
+                                  RANDOM_SEED_BUFFER_SIZE,
+                                  &ExtraSeed[0]
+                                  );
+          DEBUG ((DEBUG_INFO, "GetRNG's default algorithm - Status = %r\n", Status));
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Add default algo support for ARM platforms
Current logic assumes that all ARM chips support the RNDR instruction, or at least have one of the 3 algorithms listed.
Related code:
```
MdePkg/Library/BaseRngLib/AArch64/Rndr.c
mRndrSupported = !!((Isar0 >> ARM_ID_AA64ISAR0_EL1_RNDR_SHIFT) & ARM_ID_AA64ISAR0_EL1_RNDR_MASK);
if (!mRndrSupported) {
  return EFI_UNSUPPORTED;
}
```
Add default algo support to fit more ARM platforms.

## How This Was Tested

Tested on HW, DFCI `EncryptRecoveryChallenge` and `GetRecoveryChallenge` work as expected, will use the default algo in the system.
