### PR TITLE
DfciPkg/DfciRecoveryLib: Add support for Arm RNDR RNG algorithm

### DIFF
--- a/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.inf
+++ b/DfciPkg/Library/DfciRecoveryLib/DfciRecoveryLib.inf
@@ -47,6 +47,7 @@
   gEfiRngAlgorithmSp80090Ctr256Guid
   gEfiRngAlgorithmSp80090Hmac256Guid
   gEfiRngAlgorithmSp80090Hash256Guid
+  gEfiRngAlgorithmArmRndr
 
 
 ## Required for drivers.


### PR DESCRIPTION
## Description

1. Consolidate logic for determining whether the RNG protocol is available and a secure algorithm is supported by the platform in DfciRecoveryLib.c.
2. Update the list of algorithms that are considered secure for the purposes of DFCI usage to include `gEfiRngAlgorithmArmRndr` for a DRBG via the Arm RNDR register.

Platforms producing `gEfiRngAlgorithmArmRndr` should ensure it supports NIST SP800-90B compliance as described in https://developer.arm.com/documentation/100685/0000/Overview-of-Arm-True-Random-Number-Generator--TRNG-.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- Platform test in progress

## Integration Instructions

- `gEfiRngAlgorithmArmRndr` will be used if present in the RNG algorithm.