### PR TITLE
CISettings.py: Update Common/MU branch to 202502

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -186,7 +186,7 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             {
                 "Path": "Common/MU",
                 "Url": "https://github.com/microsoft/mu_plus.git",
-                "Branch": "release/202405"
+                "Branch": "release/202502"
             },
         ]
 


### PR DESCRIPTION
## Description

The branch is still on `release/202405` while `MU_BASECORE` is on `release/202502`. Now they are both on `release/202502`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Local CI
- Verify `Common/MU` resolves to `release/202502` with `stuart_ci_setup`

## Integration Instructions

- N/A