### PR TITLE
DfciPkg: DfciMenu Fix ClangDwarf compile.

### DIFF
--- a/DfciPkg/Application/DfciMenu/DfciRequest.c
+++ b/DfciPkg/Application/DfciMenu/DfciRequest.c
@@ -2027,6 +2027,7 @@ EnableDfciCertificate (
 
 STATIC
 UINTN
+EFIAPI
 GetResponseMsgLength (
   IN  CONST CHAR8  *FormatMessage,
   ...


### PR DESCRIPTION
## Description
When comping with clangdwarf, the abi defaults to system v abi. The use of VA_ARG with clang, defaults to the msabi version.

Functions that use VA_ARG should be declared as EFIAPI. In this particular case, the function is internal, and was not declared with EFIAPI. Adding the missing declaration resolves the build error.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Testing while building a platform using TOOL_CHAIN_TAG=CLANGDWARF

## Integration Instructions
No integration necessary