### PR TITLE
DfciManager: detect SettingsAccess-after-EndOfDxe re-entry

### DIFF
--- a/DfciPkg/DfciManager/DfciManager.c
+++ b/DfciPkg/DfciManager/DfciManager.c
@@ -864,15 +864,22 @@ ProcessMailBoxes (
 
   DEBUG ((DEBUG_INFO, "%a %a: ProcessMailboxes Entry\n", _DBGMSGID_, __FUNCTION__));
 
-  // Skip if the mailboxes were already processed and freed this boot.
-  // FreeManagerData() on the normal exit below NULLs every mManagerData[].Data.
-  // ProcessPacket NULL-checks its input, but the unenroll checks in this
-  // function dereference MgrData->Data->Unenroll directly, so a re-entry
-  // after completion would fault there. The delayed-processing path keeps
-  // Data allocated (EARLY_EXIT does not free), so a legitimate re-run is
-  // unaffected.
+  // mManagerData[MGR_IDENTITY].Data is non-NULL after InitializePacket and is set
+  // to NULL only by FreeManagerData(), which runs on the normal completion path
+  // below and on the entry error path. The delayed-processing path exits via
+  // EARLY_EXIT and does not free. Data == NULL here therefore indicates a re-entry
+  // after completion, which occurs when SettingsAccess is installed after EndOfDxe
+  // has already processed and freed the mailboxes (DFCI StartOfBds signaled after
+  // EndOfDxe). Continuing would dereference the freed MgrData->Data->Unenroll below.
   if (mManagerData[MGR_IDENTITY].Data == NULL) {
-    DEBUG ((DEBUG_INFO, "%a %a: Manager data already processed; skipping.\n", _DBGMSGID_, __FUNCTION__));
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a %a: Re-entered after completion; SettingsAccess installed after EndOfDxe. "
+      "DFCI StartOfBds must be signaled before EndOfDxe.\n",
+      _DBGMSGID_,
+      __FUNCTION__
+      ));
+    ASSERT (FALSE);
     return EFI_SUCCESS;
   }
 

--- a/DfciPkg/DfciManager/DfciManager.c
+++ b/DfciPkg/DfciManager/DfciManager.c
@@ -864,6 +864,18 @@ ProcessMailBoxes (
 
   DEBUG ((DEBUG_INFO, "%a %a: ProcessMailboxes Entry\n", _DBGMSGID_, __FUNCTION__));
 
+  // Skip if the mailboxes were already processed and freed this boot.
+  // FreeManagerData() on the normal exit below NULLs every mManagerData[].Data.
+  // ProcessPacket NULL-checks its input, but the unenroll checks in this
+  // function dereference MgrData->Data->Unenroll directly, so a re-entry
+  // after completion would fault there. The delayed-processing path keeps
+  // Data allocated (EARLY_EXIT does not free), so a legitimate re-run is
+  // unaffected.
+  if (mManagerData[MGR_IDENTITY].Data == NULL) {
+    DEBUG ((DEBUG_INFO, "%a %a: Manager data already processed; skipping.\n", _DBGMSGID_, __FUNCTION__));
+    return EFI_SUCCESS;
+  }
+
   // Process all packets in this order.  If any identity packet state is set to
   // DFCI_PACKET_STATE_DATA_DELAYED_PROCESSING, ProcessPacket will register an EndOfDxe
   // handler and return EFI_MEDIA_CHANGED.


### PR DESCRIPTION
`ProcessMailBoxes` dereferences `MgrData->Data->Unenroll` directly. On the normal completion path `FreeManagerData()` sets every `mManagerData[].Data` to NULL, so a subsequent invocation faults on a NULL read.

A subsequent invocation occurs when SettingAccess is installed after DfciManager has already processed and freed the mailboxes. When a platform signals DFCI StartOfBds after EndOfDxe, the entry-point invocation completes at EndOfDxe, and the later SettingAccess install fires the protocol notify into `SettingAccessCallback`.

This condition is a platform phase-ordering defect: DFCI StartOfBds must be signaled before EndOfDxe.

This change detects the condition at the top of `ProcessMailBoxes` and reports it rather than faulting. `mManagerData[MGR_IDENTITY].Data == NULL` on entry indicates re-entry after completion; the change logs `DEBUG_ERROR` naming the required ordering, asserts, and returns without touching freed state. On release builds the assert compiles out and the early return prevents the NULL dereference.

The delayed-processing path is unaffected: it exits via EARLY_EXIT without freeing, so `Data` remains allocated and a legitimate deferred re-run proceeds normally.
